### PR TITLE
Fix #35 [9.2] Downloading Dashboard's PNG doesn't work in Firefox

### DIFF
--- a/inc/helper.class.php
+++ b/inc/helper.class.php
@@ -140,6 +140,7 @@ class PluginMydashboardHelper {
          $graph .= "<div class='bt-col-md-2 center'>";
          $name  = $params['name'];
          $graph .= "<button class='btn btn-primary btn-sm' onclick='downloadGraph(\"$name\");'>" . __("Save as PNG", "mydashboard") . "</button>";
+         $graph .= "<a href='#' id='download'></a>";
          $graph .= "</div>";
       }
       $graph .= "</div>";

--- a/inc/menu.class.php
+++ b/inc/menu.class.php
@@ -1235,7 +1235,7 @@ class PluginMydashboardMenu extends CommonGLPI {
 //             if (!isChartRendered) return; // return if chart not rendered
                 html2canvas(document.getElementById(id), {
                  onrendered: function(canvas) {
-                     var link = document.createElement('a');
+                     var link = $('#download').get(0);
                      link.href = canvas.toDataURL('image/png');
                      link.download = 'myChart.png';
                      link.click();


### PR DESCRIPTION
Fix #35 [9.2] Downloading Dashboard's PNG doesn't work in Firefox