### PR TITLE
fix(css): do not include css file on login page

### DIFF
--- a/reports/alert.class.php
+++ b/reports/alert.class.php
@@ -2256,7 +2256,8 @@ class PluginMydashboardAlert extends CommonDBTM {
       if (file_exists($css_file)
           && !$nb
           && $nb_maintenance == 0
-          && $public == 1) {
+          && $public == 1
+          && (strpos($_SERVER['REQUEST_URI'], "index.php") === false)) {
          $wl .= Html::css(PLUGIN_MYDASHBOARD_NOTFULL_DIR."/css/hideinfo.css");
       }
       return $wl;


### PR DESCRIPTION
GLPI login page with ```oauthSSO``` is broken when ```MyDashboard``` is enabled

![image](https://user-images.githubusercontent.com/7335054/159657673-5b95b46b-5541-4d0e-bdeb-e6ef60996792.png)

This PR fix this